### PR TITLE
Fix package in GeoIP2::Role::Model::HasSubdivisions

### DIFF
--- a/lib/GeoIP2/Role/Model/HasSubdivisions.pm
+++ b/lib/GeoIP2/Role/Model/HasSubdivisions.pm
@@ -1,4 +1,4 @@
-package GeoIP2::Role::Model;
+package GeoIP2::Role::Model::HasSubdivisions;
 
 use strict;
 use warnings;


### PR DESCRIPTION
This fixes the package in GeoIP2::Role::Model::HasSubdivisions.  This wasn't noticed in the past, because the only place it was composed into also composed the incorrect package listed in the file.  Due to a bug, Moo wasn't catching this error in the past.  The next release will fix that, breaking this module.
