### PR TITLE
use B;

### DIFF
--- a/lib/GeoIP2/Role/Model.pm
+++ b/lib/GeoIP2/Role/Model.pm
@@ -13,6 +13,7 @@ use GeoIP2::Record::RepresentedCountry;
 use GeoIP2::Record::Traits;
 use GeoIP2::Types qw( ArrayRef HashRef );
 use Sub::Quote qw( quote_sub );
+use B;
 
 use Moo::Role;
 


### PR DESCRIPTION
i'm not sure if this is the 'correct' fix or not, but under ubuntu 14 LTS (perl 5.18.2) was getting:

``` bash
Undefined subroutine &B::perlstring called at /usr/local/share/perl/5.18.2/GeoIP2/Role/Model.pm line 63.
Compilation failed in require at /usr/local/share/perl/5.18.2/GeoIP2/Database/Reader.pm line 9.
BEGIN failed--compilation aborted at /usr/local/share/perl/5.18.2/GeoIP2/Database/Reader.pm line 9.
Compilation failed in require at lib/CIF/Meta/GeoIP.pm line 8.
```

my guess this might have to do with perl getting more stuff "out of the core", but i've been wrong before. citing this as an example. 
