### PR TITLE
Move throw() outside of try block.

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@
 
 - Updated documentation to clarify what the accuracy radius is and that it
   is now included in City.
+- Exceptions are now correctly thrown for responses containing JSON but no code
+  or error keys.
 
 
 2.003001 2016-04-25

--- a/lib/GeoIP2/WebService/Client.pm
+++ b/lib/GeoIP2/WebService/Client.pm
@@ -224,9 +224,6 @@ sub _handle_4xx_status {
         if ( $response->content_type() =~ /json/ ) {
             try {
                 $body = $self->_json()->decode($content);
-                GeoIP2::Error::Generic->throw( message =>
-                        'Response contains JSON but it does not specify code or error keys'
-                ) unless $body->{code} && $body->{error};
             }
             catch {
                 GeoIP2::Error::HTTP->throw(
@@ -236,6 +233,9 @@ sub _handle_4xx_status {
                     uri         => $uri,
                 );
             };
+            GeoIP2::Error::Generic->throw( message =>
+                    'Response contains JSON but it does not specify code or error keys'
+            ) unless $body->{code} && $body->{error};
         }
         else {
             GeoIP2::Error::HTTP->throw(

--- a/t/GeoIP2/WebService/Client.t
+++ b/t/GeoIP2/WebService/Client.t
@@ -299,13 +299,13 @@ my $ua = Mock::LWP::UserAgent->new(
     my $e = exception { $client->country( ip => '1.2.3.8' ) };
     isa_ok(
         $e,
-        'GeoIP2::Error::HTTP',
+        'GeoIP2::Error::Generic',
         'exception thrown when web service returns a 4xx error with a JSON body but no code and error keys'
     );
 
     like(
         $e->message(),
-        qr/\Qit did not include the expected JSON body: Response contains JSON but it does not specify code or error keys/,
+        qr/\QResponse contains JSON but it does not specify code or error keys/,
         'error contains expected text'
     );
 }


### PR DESCRIPTION
The previous iteration of this code immediately caught the exception
after it was thrown.