### PR TITLE
Do not use lib from web-service-request tool

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,7 +42,6 @@ my %WriteMakefileArgs = (
     "Throwable::Error" => 0,
     "Try::Tiny" => 0,
     "URI" => 0,
-    "lib" => 0,
     "namespace::clean" => 0,
     "strict" => 0,
     "warnings" => 0
@@ -60,6 +59,7 @@ my %WriteMakefileArgs = (
     "Test::More" => "0.96",
     "Test::Number::Delta" => 0,
     "base" => 0,
+    "lib" => 0,
     "utf8" => 0
   },
   "VERSION" => "2.006003",

--- a/bin/web-service-request
+++ b/bin/web-service-request
@@ -5,8 +5,6 @@ use 5.008;
 use strict;
 use warnings;
 
-use lib 'lib';
-
 use Data::Dumper;
 use Getopt::Long;
 use GeoIP2::WebService::Client;


### PR DESCRIPTION
Adding a relative path to @INC is insecure when running the script
from a world-writable working directory. This patch removes the
useless "use lib" from web-service-request.

Signed-off-by: Petr Písař <ppisar@redhat.com>